### PR TITLE
[WiiU] Aroma CFW Compatibility

### DIFF
--- a/libretro/Makefile.libretro
+++ b/libretro/Makefile.libretro
@@ -180,8 +180,8 @@ else ifeq ($(platform), wiiu)
        CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
        CXX = $(DEVKITPPC)/bin/powerpc-eabi-g++$(EXE_EXT)
        AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
-       COMMONFLAGS += -DWIIU -DHW_RVL -mwup -mcpu=750 -meabi -mhard-float
-       COMMONFLAGS += -U__INT32_TYPE__ -U __UINT32_TYPE__ -D__INT32_TYPE__=int
+       COMMONFLAGS += -DWIIU -DHW_RVL -mcpu=750 -meabi -mhard-float
+       COMMONFLAGS += -ffunction-sections -fdata-sections -D__wiiu__ -D__wut__
        STATIC_LINKING = 1
        FLAGS += $(COMMONFLAGS) 
 #-Iutils/zlib


### PR DESCRIPTION
This update will make the Core compatible with the soon to be released Aroma Retroarch port.
This should also be Tiramisu safe too so should be good to merge :)